### PR TITLE
Fixes #10

### DIFF
--- a/lib/latex-document-outline-view.js
+++ b/lib/latex-document-outline-view.js
@@ -35,7 +35,7 @@ export default class LatexDocumentOutlineView {
 
     this.structure = this.manager.getStructure(this.mainFile, (structure || {}), {part:0, chapter:0, section:0, subsection:0, subsubsection:0});
     this.updateView();
-    var self = this;
+    let self = this;
 
     atom.workspace.observeTextEditors(function(editor){
       editor.onDidSave(function(event) {
@@ -52,7 +52,7 @@ export default class LatexDocumentOutlineView {
         return;
       }
 
-      htmlString = ''
+      let htmlString = '';
       if (this.structure.parts) {
         htmlString += `<ul class="collapse">`;
         this.structure.parts.forEach(function(part) {
@@ -191,29 +191,28 @@ export default class LatexDocumentOutlineView {
         htmlString += `</ul>`;
       }
       this.message.innerHTML = htmlString;
-      links = this.message.getElementsByClassName("open");
-      for (i=0; i<links.length; i++) {
-        a = links[i];
-        this.addEventListenner(a)
+      const links = this.message.getElementsByClassName("open");
+      for (let i=0; i<links.length; i++) {
+        this.addEventListenner(links[i])
       }
 
-      carets = this.message.getElementsByClassName('caret');
-      for (i=0; i< carets.length; i++) {
-        caret = carets[i];
+      const carets = this.message.getElementsByClassName('caret');
+      for (let i=0; i< carets.length; i++) {
+        let caret = carets[i];
         caret.addEventListener('click', this.collapse.bind(this, caret));
       }
     });
   }
 
   collapse(node, e) {
-    index = node.dataset.index;
-    s = index.split("-");
-    obj = this.structure;
-    for (i in s) {
+    const index = node.dataset.index;
+    const s = index.split("-");
+    let obj = this.structure;
+    for (let i in s) {
       obj = obj[indices[i]][s[i]];
     }
-    collapse = node.parentNode.nextSibling.nextSibling;
-    figures = node.parentNode.nextSibling;
+    const collapse = node.parentNode.nextSibling.nextSibling;
+    const figures = node.parentNode.nextSibling;
     if (node.classList.contains('chevron-down')) {
       node.classList.remove("chevron-down");
       node.classList.add("chevron-right");
@@ -242,10 +241,9 @@ export default class LatexDocumentOutlineView {
 
   addEventListenner(a) {
     a.addEventListener('click', (ev) => {
-      filename = a.dataset.file;
-      line = a.dataset.line || 1;
-      const exists = fs.existsSync(filename);
-      if (exists) {
+      const filename = a.dataset.file;
+      const line = a.dataset.line || 1;
+      if (fs.existsSync(filename)) {
         atom.workspace.open(filename, {initialLine: line-1});
       } else {
         atom.beep();


### PR DESCRIPTION
Apparently variable creation needs to be strict in Pulsar 1.107.1 - and it won't hurt in other environment. Thus the commit uses let and const when creating any variable (and replace the deprecated var too).

Tested on Windows 10 with Pulsar 1.107.1.