### PR TITLE
Upgrade margin and collapse behavior

### DIFF
--- a/lib/latex-document-outline-view.js
+++ b/lib/latex-document-outline-view.js
@@ -54,13 +54,15 @@ export default class LatexDocumentOutlineView {
 
       let htmlString = '';
       if (this.structure.parts) {
-        htmlString += `<ul class="collapse">`;
+        if (this.structure.parts.length>1) { // EM: skip the <ul> if there is no part in the document
+          htmlString += `<ul class="collapse">`;
+        }
         this.structure.parts.forEach(function(part) {
           if (part) {
             if (part.title) {
               htmlString += `<li>
                               <div>
-                                <i class='caret octicon ${chevron(part.chapters, part.collapsed)}' data-index="${part.index}"></i>
+                                <i class='caret octicon ${chevron(!!part.chapters||!!part.figures.length, part.collapsed)}' data-index="${part.index}"></i>
                                 <a class="part open" data-line="${part.line}" data-file="${part.file}">
                                   ${part.title}
                                 </a>
@@ -69,19 +71,21 @@ export default class LatexDocumentOutlineView {
             if (part.figures) {
               htmlString += `<ul class="figures ${part.collapsed? 'hidden' : ''}">`
               part.figures.forEach(function(figure){
-                htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file=${part.file}>${figure.title}</a></li>`
+                htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file="${part.file}">${figure.title}</a></li>`
               });
               htmlString += `</ul>`
             }
 
             if (part.chapters) {
-              htmlString += `<ul class="collapse ${part.collapsed? 'hidden' : ''}">`;
+              if (part.chapters.length>1) { // EM: skip the <ul> if there is no chapter in the document
+                htmlString += `<ul class="collapse ${part.collapsed? 'hidden' : ''}">`;
+              }
               part.chapters.forEach(function(chapter) {
                 if (chapter) {
                   if (chapter.title) {
                     htmlString += `<li>
                                     <div>
-                                      <i class='caret octicon ${chevron(chapter.sections, chapter.collapsed)}' data-index="${chapter.index}"></i>
+                                      <i class='caret octicon ${chevron(!!chapter.sections||!!chapter.figures.length, chapter.collapsed)}' data-index="${chapter.index}"></i>
                                       <a class="chapter open" data-line="${chapter.line}" data-file="${chapter.file}">
                                         ${chapter.title}
                                       </a>
@@ -90,7 +94,7 @@ export default class LatexDocumentOutlineView {
                   if (chapter.figures) {
                     htmlString += `<ul class="figures ${chapter.collapsed? 'hidden' : ''}">`
                     chapter.figures.forEach(function(figure){
-                      htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file=${chapter.file}>${figure.title}</a></li>`
+                      htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file="${chapter.file}">${figure.title}</a></li>`
                     });
                     htmlString += `</ul>`
                   }
@@ -102,7 +106,7 @@ export default class LatexDocumentOutlineView {
                         if (section.title) {
                           htmlString += `<li>
                                           <div>
-                                            <i class='caret octicon ${chevron(section.subsections, section.collapsed)}' data-index="${section.index}"></i>
+                                            <i class='caret octicon ${chevron(!!section.subsections||!!section.figures.length, section.collapsed)}' data-index="${section.index}"></i>
                                             <a class="section open" data-line="${section.line}" data-file="${section.file}">
                                               ${section.title}
                                             </a>
@@ -111,7 +115,7 @@ export default class LatexDocumentOutlineView {
                         if (section.figures) {
                           htmlString += `<ul class="figures ${section.collapsed? 'hidden' : ''}">`
                           section.figures.forEach(function(figure){
-                            htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file=${section.file}>${figure.title}</a></li>`
+                            htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file="${section.file}">${figure.title}</a></li>`
                           });
                           htmlString += `</ul>`
                         }
@@ -123,7 +127,7 @@ export default class LatexDocumentOutlineView {
                               if (subsection.title) {
                                 htmlString += `<li>
                                                 <div>
-                                                  <i class='caret octicon ${chevron(subsection.subsubsections, subsection.collapsed)}' data-index="${subsection.index}"></i>
+                                                  <i class='caret octicon ${chevron(!!subsection.subsubsections||!!subsection.figures.length, subsection.collapsed)}' data-index="${subsection.index}"></i>
                                                   <a class="subsection open" data-line="${subsection.line}" data-file="${subsection.file}">
                                                     ${subsection.title}
                                                   </a>
@@ -132,7 +136,7 @@ export default class LatexDocumentOutlineView {
                               if (subsection.figures) {
                                 htmlString += `<ul class="figures ${subsection.collapsed? 'hidden' : ''}">`
                                 subsection.figures.forEach(function(figure){
-                                  htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file=${subsection.file}>${figure.title}</a></li>`
+                                  htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file="${subsection.file}">${figure.title}</a></li>`
                                 });
                                 htmlString += `</ul>`
                               }
@@ -144,19 +148,21 @@ export default class LatexDocumentOutlineView {
                                     if (subsubsection.title) {
                                       htmlString += `<li>
                                                       <div>
-                                                        <i class='caret octicon' data-index="${subsubsection.index}"></i>
+                                                        <i class='caret octicon ${chevron(!!subsubsection.figures.length, subsection.collapsed)}' data-index="${subsubsection.index}"></i>
                                                         <a class="subsubsection open" data-line="${subsubsection.line}" data-file="${subsubsection.file}">
                                                           ${subsubsection.title}
                                                         </a>
-                                                      </div>
-                                                    </li>`;
+                                                      </div>`;
                                     }
                                     if (subsubsection.figures) {
                                       htmlString += `<ul class="figures ${subsubsection.collapsed? 'hidden' : ''}">`
                                       subsubsection.figures.forEach(function(figure){
-                                        htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file=${subsubsection.file}>${figure.title}</a></li>`
+                                        htmlString += `<li class="${figure.type}"><a class="open" data-line="${figure.line}" data-file="${subsubsection.file}">${figure.title}</a></li>`
                                       });
                                       htmlString += `</ul>`
+                                    }
+                                    if (subsubsection.title) {
+                                      htmlString += `</li>`;
                                     }
                                   }
                                 });
@@ -181,14 +187,18 @@ export default class LatexDocumentOutlineView {
                   }
                 }
               });
-              htmlString += `</ul>`;
+              if (part.chapters.length>1) { // EM: no need to close the <ul> if there is no chapter
+                htmlString += `</ul>`;
+              }
             }
             if (part.title) {
               htmlString += `</li>`;
             }
           }
         });
-        htmlString += `</ul>`;
+        if (this.structure.parts.length>1) { // EM: no need to close the <ul> if there is no part
+          htmlString += `</ul>`;
+        }
       }
       this.message.innerHTML = htmlString;
       const links = this.message.getElementsByClassName("open");
@@ -216,14 +226,18 @@ export default class LatexDocumentOutlineView {
     if (node.classList.contains('chevron-down')) {
       node.classList.remove("chevron-down");
       node.classList.add("chevron-right");
-      collapse.classList.add('hidden');
+      if (collapse) {
+        collapse.classList.add('hidden');
+      }
       figures.classList.add('hidden');
       obj.collapsed = true;
     }
     else if (node.classList.contains('chevron-right')) {
       node.classList.remove("chevron-right");
       node.classList.add("chevron-down");
-      collapse.classList.remove('hidden');
+      if (collapse) {
+        collapse.classList.remove('hidden');
+      }
       figures.classList.remove('hidden');
       obj.collapsed = false;
     }

--- a/styles/latex-document-outline.less
+++ b/styles/latex-document-outline.less
@@ -23,6 +23,9 @@
     ul.figures {
       padding-left: 30px;
     }
+    > ul:first-child {
+      padding-left: 5px;			
+    }
     ul {
       list-style-type: none;
       padding-left: 15px;


### PR DESCRIPTION
- decrease the left padding of the outline to save space (removed unnecessary ul element when part and chapter are not used, and decreased the left-most ul element margin)
- allow to collapse section even if they contain only "figures" (that is figure, table or theorem)
- fix li for subsubsection and add "" around file name in link to avoid problem with file name with space

Only tested on Win-10 for a book and an article.
Probably require to bump version number to 1.4.